### PR TITLE
Update splt.js: Support html entity decoding

### DIFF
--- a/splt.js
+++ b/splt.js
@@ -4,6 +4,13 @@ function splt({ target = '.splt', reveal = false }) {
   //grab instances
   const inst = document.querySelectorAll(target);
 
+  // MOD - support for html entity decoding
+  const decoded = function (encodedStr) {
+    let textarea = document.createElement('textarea')
+    textarea.innerHTML = encodedStr
+    return textarea.value
+  };
+
   for (let a = 0; a < inst.length; a++) {
     inst[a].setAttribute('id', 'i' + [a + 1]);
 
@@ -11,7 +18,7 @@ function splt({ target = '.splt', reveal = false }) {
     saveOriginal.push(inst[a].innerHTML);
 
     //split instance text
-    const instChars = inst[a].innerHTML.split('');
+    const instChars = decoded(inst[a].innerHTML).split('');
     for (let b = 0; b < instChars.length; b++) {
       //nest child span
       const span = document.createElement('span');


### PR DESCRIPTION
Hey Logan,
after failing to workaround this issue around spltjs due to the nature of .innerHTML always escaping those HTML entities I tried to apply some changes to your script instead which finally worked. It would be nice if you'd merge this proposal one way or another. The method used to decode those entities (by using textarea elements) might not be the smartest but it's definitely an easy one and working. Maybe see https://thelinuxcode.com/decode-html-entities-javascript/ for reference. Thanks!